### PR TITLE
Fixes type of BigInteger.toString

### DIFF
--- a/src/BigInteger.re
+++ b/src/BigInteger.re
@@ -769,13 +769,13 @@ external valueOf: t => int = "valueOf";
  * Internal BigInteger.toString
  */
 [@bs.send]
-external _toString: (t, int) => int = "toString";
+external _toString: (t, int) => string = "toString";
 
 /**
- * Converts a bigInt to a native Javascript number. Converts a bigInt to a
- * string. There is an optional radix parameter (which **defaults to 10**) that
- * converts the number to the given radix. Digits in the range `10-35` will use
- * the letters `a-z`. Bases larger than 36 are supported. If a digit is greater
- * than or equal to 36, it will be enclosed in angle brackets.
+ * Converts a bigInt to a string. There is an optional radix parameter
+ * (which **defaults to 10**) that converts the number to the given radix.
+ * Digits in the range `10-35` will use the letters `a-z`. Bases larger
+ * than 36 are supported. If a digit is greater  * than or equal to 36,
+ * it will be enclosed in angle brackets.
  */
 let toString = (t, ~base=10, ()) => _toString(t, base);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-bs-platform@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.npmjs.org/bs-platform/-/bs-platform-5.2.1.tgz#3f76f6d4f4c7255296375a8104c8be332770b691"
-  integrity sha512-3ISP+RBC/NYILiJnphCY0W3RTYpQ11JGa2dBBLVug5fpFZ0qtSaL3ZplD8MyjNeXX2bC7xgrWfgBSn8Tc9om7Q==
+bs-platform@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-6.2.1.tgz#30266c7f23a3b323e1fc9596a9a6eb9f053981b4"
+  integrity sha512-FmQ8kYV52A0Y302qh6o0/J9TO+kHzsjGQnsjrg/ONUYIY/jWzBnt9dCBO6EBnaEKfFJLqk5JrUDCxuihqtTcnw==


### PR DESCRIPTION
An internal helper was incorrectly typed as returning an int,
rather than a string.